### PR TITLE
Add (optional) GetCapabilities request for missing params

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ A prebuilt UMD bundle is available under `dist/`.
 | `extraParams` | `Record<string, any>` | `{}` | Extra query params (e.g., token) |
 | `crossOrigin` | `string\|true` | `undefined` | Sets `crossorigin` on tile images |
 | `baseQuery` | `string` | `undefined` | Appended before WMTS KVPs |
+| `useGetCapabilities` | `boolean` | `false` | Use server GetCapabilities to auto-configure |
 
 ---
 

--- a/src/leaflet.tilelayer.wmts.d.ts
+++ b/src/leaflet.tilelayer.wmts.d.ts
@@ -15,6 +15,7 @@ declare module '@alcalin/leaflet-tilelayer-wmts' {
     requestEncoding?: 'REST' | 'KVP' | 'RESTful';
     tileMatrixLabels?: Array<string | number>;
     googleMapsCompatible?: boolean;
+    useGetCapabilities?: boolean;           // if true, make a GetCapabilities request to fill missing params
     extraParams?: Record<string, string | number | boolean>;
     baseQuery?: string;
     crossOrigin?: boolean | '' | 'anonymous' | 'use-credentials';

--- a/src/leaflet.tilelayer.wmts.js
+++ b/src/leaflet.tilelayer.wmts.js
@@ -210,7 +210,7 @@ export class WMTS extends L.TileLayer {
         }
       ]));
     const layer = layers[this._wmtsParams.LAYER];
-    const tileMatrixLabels = tileMatrixSetsLabels[layer.tileMatrixSet]; // The labels for the set used by our layer
+    const tileMatrixLabels = tileMatrixSetsLabels[this._wmtsParams.TILEMATRIXSET ?? layer.tileMatrixSet]; // The labels for the set used by our layer
 
     // Only set params that were not explicitly provided.
     // We make the assumption that even if the user explicitly provided "default" for


### PR DESCRIPTION
Added a new option `useGetCapabilities` to `WMTS`. When flagged as true, the layer makes a `GetCapabilities` request to retrieve the layer's:
- tile matrix set
- tile matrix labels
- default style
- format

These values from the server are then used for `getTileUrl` requests, as long as the user hasn't provided their own values.

The main benefit of this to alleviate the need of specifying `tileMatrixLabels` for each layer, in the case of working with many different layers.

## Examples
### Example 1
```
wmts("https://tiles.arcgis.com/tiles/tPxy1hrFDhJfZ0Mf/arcgis/rest/services/Antarctica_and_the_Southern_Ocean/MapServer/WMTS", {
  layer: "Antarctica_and_the_Southern_Ocean",
  useGetCapabilities: true,
});
```

When the layer is created, a request to https://tiles.arcgis.com/tiles/tPxy1hrFDhJfZ0Mf/arcgis/rest/services/Antarctica_and_the_Southern_Ocean/MapServer/WMTS?SERVICE=WMTS&REQUEST=GetCapabilities&VERSION=1.0.0 is made.
With some parsing server provides this information for the `Antarctica_and_the_Southern_Ocean` layer:
- **TileMatrixSet:** `"default028mm"`
- **TileMatrix identifiers (labels):** `[3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]`
- **Format:** `"image/jpgpng"`
- **Style(with `isDefault="true"`):** `"default"`

These can then be used for `GetTile` requests, like so:
https://tiles.arcgis.com/tiles/tPxy1hrFDhJfZ0Mf/arcgis/rest/services/Antarctica_and_the_Southern_Ocean/MapServer/WMTS?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=Antarctica_and_the_Southern_Ocean&STYLE=default&TILEMATRIXSET=default028mm&FORMAT=image/jpgpng&WIDTH=256&HEIGHT=256&TILEMATRIX=5&TILEROW=15&TILECOL=15

### Example 2
```
wmts("https://geoserver-seamapantarctica.imas.utas.edu.au/geoserver/gwc/service/wmts", {
  layer: "terrain:ANTGG2022_bed_elevation_composite",
  useGetCapabilities: true,
  tileMatrixSet: "EPSG:3031-BAS",
  style: "",
});
```

A request to https://geoserver-seamapantarctica.imas.utas.edu.au/geoserver/gwc/service/wmts?SERVICE=WMTS&REQUEST=GetCapabilities&VERSION=1.0.0 is made.
This provides for the `terrain:ANTGG2022_bed_elevation_composite` layer:
- **TileMatrixSet:** `"EPSG:3031-BAS"`
- **TileMatrix identifiers (labels):** `["EPSG:3031-BAS:0", "EPSG:3031-BAS:1", "EPSG:3031-BAS:2",  ..., "EPSG:3031-BAS:16"]`
- **Format:** `"image/png"`
- **Style(with `isDefault="true"`):** `""`

However because we already provided `tileMatrixSet` and `style` when creating our layer, the values retrieved are ignored (though in this example they happen to be identical to what was provided).

https://geoserver-seamapantarctica.imas.utas.edu.au/geoserver/gwc/service/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=terrain%3AANTGG2022_bed_elevation_composite&STYLE=&TILEMATRIXSET=EPSG%3A3031-BAS&FORMAT=image%2Fpng&WIDTH=256&HEIGHT=256&TILEMATRIX=EPSG%3A3031-BAS%3A2&TILEROW=17&TILECOL=16
